### PR TITLE
Remove meta viewport for now.

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="icon" type="image/vnd.microsoft.icon" href="/static/icon.ico">
         <link rel="stylesheet" href="//cdn.jsdelivr.net/editor/0.1.0/editor.css">
         <meta property="og:image" content="/static/logo.png" />


### PR DESCRIPTION
Temporary fix for #4. 

Right now, the website is not mobile-friendly, so
meta viewport makes things worse. At least it will be usable on
mobiles, albeit a bit clumsy. 

@EIREXE could you please add this?
